### PR TITLE
Fix/linux portability and language config

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ Set the `KOKORO_VOICE` environment variable in `~/.claude/settings.json`:
 
 The default voice is `af_sky`. Changes take effect on the next Claude Code session.
 
+#### Setting the Language
+
+When using a non-English voice, also set `KOKORO_LANG` so pronunciation matches
+the voice's language. Without it, the engine defaults to `en-us` and a French
+voice will sound anglicized.
+
+```json
+{
+  "env": {
+    "KOKORO_VOICE": "ff_siwis",
+    "KOKORO_LANG": "fr-fr"
+  }
+}
+```
+
+Supported language codes (run `kokoro-tts --help-languages` for the live list):
+`cmn`, `en-gb`, `en-us`, `fr-fr`, `it`, `ja`. Default: `en-us`.
+
 #### Available Voices (54 total)
 
 **American English:**

--- a/hooks/tts-pretooluse-hook.sh
+++ b/hooks/tts-pretooluse-hook.sh
@@ -3,6 +3,7 @@
 
 # Voice configuration - can be set via KOKORO_VOICE env var in ~/.claude/settings.json
 VOICE="${KOKORO_VOICE:-af_sky}"
+LANG_CODE="${KOKORO_LANG:-en-us}"
 
 # Audio ducking configuration - lowers Apple Music volume while TTS plays (like Google Maps in CarPlay)
 # macOS only - uses AppleScript to control Apple Music's internal volume
@@ -151,7 +152,7 @@ if [ -n "$claude_response" ] && [ ${#claude_response} -gt 10 ]; then
   fi
 
   # Run kokoro-tts in background and capture PID for audio ducking restore
-  kokoro-tts "$tmpfile" --voice "$VOICE" --stream --model "MODEL_PATH_PLACEHOLDER/kokoro-v1.0.onnx" --voices "MODEL_PATH_PLACEHOLDER/voices-v1.0.bin" >>/tmp/kokoro-hook.log 2>&1 &
+  kokoro-tts "$tmpfile" --voice "$VOICE" --lang "$LANG_CODE" --stream --model "MODEL_PATH_PLACEHOLDER/kokoro-v1.0.onnx" --voices "MODEL_PATH_PLACEHOLDER/voices-v1.0.bin" >>/tmp/kokoro-hook.log 2>&1 &
   TTS_PID=$!
   echo "[$(date)] Started kokoro-tts with PID: $TTS_PID" >> /tmp/kokoro-hook.log
 

--- a/hooks/tts-pretooluse-hook.sh
+++ b/hooks/tts-pretooluse-hook.sh
@@ -39,14 +39,14 @@ fi
 # Check if this is the first tool_use in the current message
 # Extract the first tool_use_id from the last assistant message
 # NOTE: Using process substitution < <(tail -r ...) instead of pipe to avoid subshell variable scope issues
-# Using tail -r instead of tac for macOS compatibility
+# Cross-platform reverse: tac on Linux, tail -r on macOS
 first_tool_use_id=""
 while IFS= read -r line; do
   if echo "$line" | jq -e '.type == "assistant"' >/dev/null 2>&1; then
     first_tool_use_id=$(echo "$line" | jq -r '.message.content[] | select(.type == "tool_use") | .id' 2>/dev/null | head -1)
     break
   fi
-done < <(tail -r "$transcript_path")
+done < <(tac "$transcript_path" 2>/dev/null || tail -r "$transcript_path")
 
 echo "[$(date)] First tool_use_id in message: $first_tool_use_id" >> /tmp/kokoro-hook.log
 
@@ -62,7 +62,7 @@ echo "[$(date)] This is the first tool use - proceeding with TTS" >> /tmp/kokoro
 # Claude Code splits responses into separate messages for text and tool_use blocks
 # We need to find text from the most recent assistant text message before the first tool use
 # NOTE: Using process substitution < <(tail -r ...) instead of pipe to avoid subshell variable scope issues
-# Using tail -r instead of tac for macOS compatibility
+# Cross-platform reverse: tac on Linux, tail -r on macOS
 found_tool_use=0
 claude_response=""
 while IFS= read -r line; do
@@ -91,7 +91,7 @@ while IFS= read -r line; do
       fi
     fi
   fi
-done < <(tail -r "$transcript_path")
+done < <(tac "$transcript_path" 2>/dev/null || tail -r "$transcript_path")
 # Truncate to 5000 characters
 claude_response="${claude_response:0:5000}"
 

--- a/hooks/tts-stop-hook.sh
+++ b/hooks/tts-stop-hook.sh
@@ -3,6 +3,7 @@
 
 # Voice configuration - can be set via KOKORO_VOICE env var in ~/.claude/settings.json
 VOICE="${KOKORO_VOICE:-af_sky}"
+LANG_CODE="${KOKORO_LANG:-en-us}"
 
 # Audio ducking configuration - lowers Apple Music volume while TTS plays (like Google Maps in CarPlay)
 # macOS only - uses AppleScript to control Apple Music's internal volume
@@ -133,7 +134,7 @@ if [ -n "$claude_response" ]; then
   fi
 
   # Run kokoro-tts in background and capture PID for audio ducking restore
-  kokoro-tts "$tmpfile" --voice "$VOICE" --stream --model "MODEL_PATH_PLACEHOLDER/kokoro-v1.0.onnx" --voices "MODEL_PATH_PLACEHOLDER/voices-v1.0.bin" >>/tmp/kokoro-hook.log 2>&1 &
+  kokoro-tts "$tmpfile" --voice "$VOICE" --lang "$LANG_CODE" --stream --model "MODEL_PATH_PLACEHOLDER/kokoro-v1.0.onnx" --voices "MODEL_PATH_PLACEHOLDER/voices-v1.0.bin" >>/tmp/kokoro-hook.log 2>&1 &
   TTS_PID=$!
   echo "[$(date)] Started kokoro-tts with PID: $TTS_PID" >> /tmp/kokoro-hook.log
 

--- a/hooks/tts-stop-hook.sh
+++ b/hooks/tts-stop-hook.sh
@@ -40,7 +40,7 @@ fi
 # Loop through messages in reverse to find text that appears AFTER tool uses completed
 # This prevents reading text that PreToolUse hook already played
 # NOTE: Using process substitution < <(tail -r ...) instead of pipe to avoid subshell variable scope issues
-# Using tail -r instead of tac for macOS compatibility
+# Cross-platform reverse: tac on Linux, tail -r on macOS
 seen_tool_result=0
 claude_response=""
 while IFS= read -r line; do
@@ -64,7 +64,7 @@ while IFS= read -r line; do
       fi
     fi
   fi
-done < <(tail -r "$transcript_path")
+done < <(tac "$transcript_path" 2>/dev/null || tail -r "$transcript_path")
 # Truncate to 5000 characters
 claude_response="${claude_response:0:5000}"
 


### PR DESCRIPTION
## Summary

  Two related changes for non-macOS / non-English users.

  ### 1. Bug fix — hooks never read the transcript on Linux

  `tts-stop-hook.sh` and `tts-pretooluse-hook.sh` use `tail -r` to walk the
  JSONL transcript in reverse. `tail -r` is a BSD/macOS extension and does
  not exist in GNU coreutils. On Linux, the command errors out immediately,
  the read loop never iterates, and `claude_response` stays empty — so the
  hook silently produces no audio for **every** Linux user.

  Symptom in the log:
  [...] Extracted response:
  [...] No response found
  on every Stop event, even though `last_assistant_message` in the hook
  input contains the full text.

  Fix: try `tac` first (GNU), fall back to `tail -r` (BSD). Both platforms
  now work.

  ```bash
  done < <(tac "$transcript_path" 2>/dev/null || tail -r "$transcript_path")

  2. Feature — KOKORO_LANG env var

  kokoro-tts defaults to en-us. With a non-English voice (e.g.
  ff_siwis for French, or any jf_* / zf_* / ef_*…), pronunciation
  remains anglicized unless --lang is passed. Users currently have no
  way to set this from settings.json.

  Add a KOKORO_LANG env var (default en-us) read the same way as
  KOKORO_VOICE, and forward it to kokoro-tts --lang.

  Example ~/.claude/settings.json:
  "env": {
    "KOKORO_VOICE": "ff_siwis",
    "KOKORO_LANG": "fr-fr"
  }

  Supported codes (from kokoro-tts --help-languages):
  cmn, en-gb, en-us, fr-fr, it, ja.

  Test plan

  - Linux (Ubuntu, GNU coreutils): hook now extracts the response and plays audio. Verified via /tmp/kokoro-hook.log.
  - Verified tac falls through cleanly when present, tail -r fallback path is unreachable on Linux.
  - macOS: not retested by me — the tac 2>/dev/null || tail -r pattern preserves macOS behavior since tac does not exist there, the || triggers, and tail -r runs as before.
  - French TTS with KOKORO_VOICE=ff_siwis + KOKORO_LANG=fr-fr: pronunciation is correctly French (vs anglicized French without the flag).

  Notes

  The two changes are split into two commits so you can cherry-pick the
  bug fix alone if you prefer to land the feature separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text-to-speech now supports configurable language selection through environment variables, defaulting to English while enabling support for additional languages

* **Improvements**
  * Enhanced cross-platform compatibility by implementing universal transcript processing methods that reliably work across macOS, Linux, and other Unix-based operating systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->